### PR TITLE
call may-log? with the log level, not ns-pattern min level

### DIFF
--- a/src/timbre_ns_pattern_level.clj
+++ b/src/timbre_ns_pattern_level.clj
@@ -15,6 +15,6 @@
                               (apply max-key count))
                      :all)
           loglevel (get ns-patterns namesp (get config :level))]
-      (when (and (taoensso.timbre/may-log? loglevel namesp)
+      (when (and (taoensso.timbre/may-log? level namesp)
                  (taoensso.timbre/level>= level loglevel))
         opts))))


### PR DESCRIPTION
When asking timbre if we can log, we should test the level of the current log message, not the min level of the namespace.